### PR TITLE
[crypto] Store sensitive dataset items in ITS

### DIFF
--- a/src/core/crypto/storage.hpp
+++ b/src/core/crypto/storage.hpp
@@ -95,7 +95,13 @@ enum StorageType : uint8_t
  */
 typedef otCryptoKeyRef KeyRef;
 
-constexpr KeyRef kInvalidKeyRef = 0x80000000; ///< Invalid `KeyRef` value (PSA_KEY_ID_VENDOR_MAX + 1).
+constexpr KeyRef kInvalidKeyRef               = 0x80000000; ///< I nvalid `KeyRef` value (PSA_KEY_ID_VENDOR_MAX + 1).
+constexpr KeyRef kNetworkKeyRef               = OPENTHREAD_CONFIG_PSA_ITS_NVM_OFFSET + 1;
+constexpr KeyRef kPskcRef                     = OPENTHREAD_CONFIG_PSA_ITS_NVM_OFFSET + 2;
+constexpr KeyRef kActiveDatasetNetworkKeyRef  = OPENTHREAD_CONFIG_PSA_ITS_NVM_OFFSET + 3;
+constexpr KeyRef kActiveDatasetPskcRef        = OPENTHREAD_CONFIG_PSA_ITS_NVM_OFFSET + 4;
+constexpr KeyRef kPendingDatasetNetworkKeyRef = OPENTHREAD_CONFIG_PSA_ITS_NVM_OFFSET + 5;
+constexpr KeyRef kPendingDatasetPskcRef       = OPENTHREAD_CONFIG_PSA_ITS_NVM_OFFSET + 6;
 
 /**
  * Determine if a given `KeyRef` is valid or not.

--- a/src/core/meshcop/dataset_local.hpp
+++ b/src/core/meshcop/dataset_local.hpp
@@ -186,6 +186,11 @@ public:
 private:
     bool IsActive(void) const { return (mType == Dataset::kActive); }
     void SetTimestamp(const Dataset &aDataset);
+#if OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE
+    void DestroyItsKeys() const;
+    void StoreItsKeys(Dataset &aDataset) const;
+    void EmplaceItsKeys(Dataset &aDataset) const;
+#endif
 
     Timestamp     mTimestamp;            ///< Active or Pending Timestamp
     TimeMilli     mUpdateTime;           ///< Local time last updated

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -562,7 +562,7 @@ void KeyManager::StoreNetworkKey(const NetworkKey &aNetworkKey, bool aOverWriteE
 {
     NetworkKeyRef keyRef;
 
-    keyRef = kNetworkKeyPsaItsOffset;
+    keyRef = Crypto::Storage::kNetworkKeyRef;
 
     if (!aOverWriteExisting)
     {
@@ -593,7 +593,7 @@ exit:
 
 void KeyManager::StorePskc(const Pskc &aPskc)
 {
-    PskcRef keyRef = kPskcPsaItsOffset;
+    PskcRef keyRef = Crypto::Storage::kPskcRef;
 
     Crypto::Storage::DestroyKey(keyRef);
 

--- a/src/core/thread/key_manager.hpp
+++ b/src/core/thread/key_manager.hpp
@@ -211,9 +211,6 @@ typedef Mac::KeyMaterial KekKeyMaterial;
 class KeyManager : public InstanceLocator, private NonCopyable
 {
 public:
-    static constexpr uint32_t kNetworkKeyPsaItsOffset = OPENTHREAD_CONFIG_PSA_ITS_NVM_OFFSET + 1;
-    static constexpr uint32_t kPskcPsaItsOffset       = OPENTHREAD_CONFIG_PSA_ITS_NVM_OFFSET + 2;
-
     /**
      * This constructor initializes the object.
      *


### PR DESCRIPTION
When OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE is
set, make sure that sensitive dataset items, such as the
network key or PSKC, are persisted using the secure
Crypto::Storage API (which should encrypt the stored data,
or use secure hardware units) instead of settings.